### PR TITLE
Issue in URL param parsing

### DIFF
--- a/cafe/plugins/http/cafe/engine/http/client.py
+++ b/cafe/plugins/http/cafe/engine/http/client.py
@@ -90,7 +90,9 @@ def _log_transaction(log, level=cclogging.logging.DEBUG):
             if 'params' in dir(response.request):
                 request_params = response.request.params
             elif '?' in request_url:
-                request_url, request_params = request_url.split('?')
+                request_list = request_url.split('?')
+                request_url = request_list[0]
+                request_params = "?".join(request_list[1:])
 
             logline = ''.join([
                 '\n{0}\nREQUEST SENT\n{0}\n'.format('-' * 12),


### PR DESCRIPTION
If the URL parameter contains a "?" character, the HTTP client will
throw a 'too many values to unpack' error and crash. Here we're just
assuming that the first "?" is the delimeter between path and params,
and any other "?" character is intentionally part of the URL param